### PR TITLE
feat: Expose docker file path as input in publish docker workflow

### DIFF
--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -26,6 +26,10 @@ on:
         type: string
         description: "Image prefix when uploading to GitHub Registry"
         required: true
+      dockerFile:
+        type: string
+        description: Path to the Dockerfile. (default ./Dockerfile)
+        required: false
       imageName:
         type: string
         description: "Name of Docker image"
@@ -79,6 +83,7 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           context: .
+          file: ${{ inputs.dockerFile }}
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
Part of FT-63992f8e-64e2-11ed-b663-629c3ddc6a3e

- [ ] I have added automatic tests where applicable.
- [X] The PR contains a description of what has been changed.
- [X] The description contains manual test instructions.
- [X] The PR contains updates to the release notes.
- [X] I have verified that the documentation is still up to date.

## Changes

Add dockerFile as option input to publish-docker workflow

## Test

Test that the workflow works as expected both when specifying and not specifying the dockerFile input.