### PR TITLE
ci: Setup npm publish script

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -1,0 +1,85 @@
+name: CD
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_call:
+    secrets:
+      token:
+        description: "The GitHub token"
+        required: true
+      npmToken:
+        description: "NPM registry token"
+        required: true
+    inputs:
+      scope:
+        type: string
+        description: "NPM scope"
+        required: false
+        default: "@ftrack"
+      registryUrl:
+        type: string
+        description: "Registry URL"
+        required: false
+        default: "https://registry.npmjs.org/"
+
+
+jobs:
+  publish-npm:
+    name: "Publish to NPM"
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_TOKEN: ${{ secrets.token || secrets.GITHUB_TOKEN }}
+
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version-file: ".nvmrc"
+          registry-url: ${{ inputs.registryUrl }}
+          scope: ${{ inputs.scope }}
+
+      # caching with actions/setup-node isn't supported with yarn 3
+      # so we use this workaround https://github.com/actions/setup-node/issues/488
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "dir=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
+        shell: bash
+      - name: Restore yarn cache
+        uses: actions/cache@v3
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: yarn-cache-folder-${{ hashFiles('**/yarn.lock', '.yarnrc.yml') }}
+          restore-keys: |
+            yarn-cache-folder-
+      - run: yarn install --immutable
+
+        # ########## RESOLVE NPM_TAG ##########
+
+        # Default to latest
+      - run: echo "NPM_TAG=latest") >> $GITHUB_ENV
+
+        # If tag is not reachable from main (i.e, we tag it from a release branch), tag it as its version name
+      - run: $(git branch --contains ${{ github.ref_name }} | grep '^* main$' || echo "NPM_TAG=${{ github.ref_name }}") >> $GITHUB_ENV
+
+        # If tag is prerelease tag, publish to prerelease channel (i.e, 1.0.0-alpha.1 -> alpha)
+      - if: startsWith(github.ref, 'refs/tags/v') && contains(github.ref_name, '-')
+        run: echo "NPM_TAG=$(echo ${{ github.ref_name }} | grep -o "\-[a-z]+" | sed "s/^-//g")" >> $GITHUB_ENV
+
+        # ########## BUMP PACKAGE VERSION ##########
+
+        # Add tag to package.json and run publish script
+      - if: startsWith(github.ref, 'refs/tags/v')
+        run: npm version --no-git-tag-version ${{ github.ref_name }}
+
+        # ############# PUBLISH TO NPM #############
+
+      - run: yarn npm publish --access public --tag ${{ env.NPM_TAG }}
+        env:
+          YARN_NPM_AUTH_TOKEN: ${{ secrets.npmToken || secrets.NPM_TOKEN }}


### PR DESCRIPTION
<!--
  [For internal use] 
  Copy the task id from the bottom of the sidebar and paste it after FTRACK-
-->

Partially resolves FT-faedda3e-64d7-11ed-86b3-42bf04dc3420

- [x] I have added automatic tests where applicable
- [x] The PR title is suitable as a release note
- [x] The PR contains a description of what has been changed
- [x] The description contains manual test instructions

## Changes

<!--
  What are you changing and what is the reason? If there are any UI changes, include a screenshot for the changes.
-->

This PR sets up the build and publish step of the new CI release flow for NPM packages.

<img width="519" alt="image" src="https://user-images.githubusercontent.com/2225828/203569361-0e509da9-f22a-4606-9880-9570aedf13cc.png">

Once this is done, a later PR will set up the automatic pushing of new version tags as well.

## Test

<!--
  How should this be tested? Include any requirements on other repositories or environment.
  For bug fixes, include the original reproduction steps.
-->

This release flow is only triggered on push of new tags that start with `v`. It's not very easy to test without actually making releases, so focus on reviewing the overall flow and implementation, and we can try it out together after merge.