### PR TITLE
fix: Linting dockerfile requires dockerFile input

### DIFF
--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -30,10 +30,12 @@ on:
         type: string
         description: Path to the Dockerfile. (default ./Dockerfile)
         required: false
+        default: ./Dockerfile
       lint:
         type: boolean
         description: "Set to true to lint Dockerfile as part of build"
         required: false
+        default: false
       imageName:
         type: string
         description: "Name of Docker image"


### PR DESCRIPTION
## Changes

Updating a workflow not specifying Dockerfile, I noticed that it linting failed without a default value, so adding a fallback.

