### PR TITLE
feat: support for additionalImages in docker, and using it as an action

### DIFF
--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -67,7 +67,6 @@ on:
         required: false
         default: ""
 
-
 jobs:
   build-and-push-image:
     name: "Build and push to registries"
@@ -81,16 +80,14 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-      # Required for image layer cache
-      - uses: docker/setup-buildx-action@v2
-
-      - name: Lint Dockerfile
-        if: ${{ inputs.lint }}
-        uses: hadolint/hadolint-action@v3.0.0
+      # required so we can reference the actions locally
+      - name: Checkout workflows repo
+        uses: actions/checkout@v3
         with:
-          dockerfile: ${{ inputs.dockerFile }}
-          failure-threshold: "warning"
-          verbose: true
+          ref: ${{ inputs.workflows-ref }}
+          path: workflows
+          repository: ftrackhq/ftrack-actions
+          token: ${{ secrets.token || secrets.GITHUB_TOKEN }}
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v2
@@ -106,35 +103,18 @@ jobs:
           username: _json_key
           password: ${{ secrets.gcrJsonKey }}
 
-      - name: Extract metadata (tags, labels) for Docker
-        id: meta
-        uses: docker/metadata-action@v4
-        env:
-          DOCKER_METADATA_PR_HEAD_SHA: true
+      - name: Build and publish
+        uses: ./workflows/actions/publish-docker
         with:
-          tags: |
-            type=ref,event=branch
-            type=ref,event=pr
-            type=sha
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}}
+          token: ${{ secrets.token || secrets.GITHUB_TOKEN }}
+          dockerFile: ${{ inputs.dockerFile }}
+          context: ${{ inputs.context }}
+          lint: ${{ inputs.lint }}
+          imageName: ${{ inputs.imageName }}
+          target: ${{ inputs.target }}
+          provenance: ${{ inputs.provenance }}
+          dockerBuildArgs: ${{ inputs.dockerBuildArgs }}
           images: |
             ${{ inputs.gcrRegistry }}/${{ inputs.gcrNamespace }}/${{ inputs.imageName }}
             ${{ inputs.ghcrRegistry }}/${{ inputs.ghcrNamespace }}/${{ inputs.imageName }}
             ${{ inputs.additionalImages }}
-
-      - name: Build and push Docker image
-        uses: docker/build-push-action@v3
-        with:
-          context: ${{ inputs.context }}
-          file: ${{ inputs.dockerFile }}
-          build-args: ${{ inputs.dockerBuildArgs }}
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-          target: ${{ inputs.target }}
-          provenance: ${{ inputs.provenance }}
-          secrets: ${{ secrets.dockerSecrets }}

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -57,11 +57,16 @@ on:
         type: string
         description: Generate provenance attestation for the build (shorthand for --attest=type=provenance). Currently not working with gcr
         required: false
-        default: false
+        default: ""
       dockerBuildArgs:
         type: string
         required: false
         default: ""
+      additionalImages:
+        type: string
+        required: false
+        default: ""
+
 
 jobs:
   build-and-push-image:
@@ -117,6 +122,7 @@ jobs:
           images: |
             ${{ inputs.gcrRegistry }}/${{ inputs.gcrNamespace }}/${{ inputs.imageName }}
             ${{ inputs.ghcrRegistry }}/${{ inputs.ghcrNamespace }}/${{ inputs.imageName }}
+            ${{ inputs.additionalImages }}
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v3

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -114,6 +114,7 @@ jobs:
           target: ${{ inputs.target }}
           provenance: ${{ inputs.provenance }}
           dockerBuildArgs: ${{ inputs.dockerBuildArgs }}
+          dockerSecrets: ${{ secrets.dockerSecrets }}
           images: |
             ${{ inputs.gcrRegistry }}/${{ inputs.gcrNamespace }}/${{ inputs.imageName }}
             ${{ inputs.ghcrRegistry }}/${{ inputs.ghcrNamespace }}/${{ inputs.imageName }}

--- a/actions/publish-docker/action.yml
+++ b/actions/publish-docker/action.yml
@@ -34,6 +34,9 @@ inputs:
     description: ""
     required: false
     default: ""
+  dockerSecrets:
+    description: "Docker build push action"
+    required: false
 
 runs:
   using: composite
@@ -77,4 +80,4 @@ runs:
         cache-to: type=gha,mode=max
         target: ${{ inputs.target }}
         provenance: ${{ inputs.provenance }}
-        secrets: ${{ secrets.dockerSecrets }}
+        secrets: ${{ inputs.dockerSecrets }}

--- a/actions/publish-docker/action.yml
+++ b/actions/publish-docker/action.yml
@@ -1,0 +1,80 @@
+name: Publish Docker
+description: Action for building and publishing docker images
+inputs:
+  token:
+    description: "The GitHub token"
+    required: true
+  dockerFile:
+    description: Path to the Dockerfile. (default ./Dockerfile)
+    required: false
+    default: ./Dockerfile
+  context:
+    description: Path to context
+    required: false
+    default: .
+  lint:
+    description: "Set to true to lint Dockerfile as part of build"
+    required: false
+  imageName:
+    description: "Name of Docker image"
+    required: true
+  target:
+    description: "Sets the target stage to build"
+    required: false
+    default: ""
+  provenance:
+    description: Generate provenance attestation for the build (shorthand for --attest=type=provenance). Currently not working with gcr
+    required: false
+    default: ""
+  dockerBuildArgs:
+    description: ""
+    required: false
+    default: ""
+  images:
+    description: ""
+    required: false
+    default: ""
+
+runs:
+  using: composite
+  steps:
+    # Required for image layer cache
+    - uses: docker/setup-buildx-action@v2
+
+    - name: Lint Dockerfile
+      if: ${{ inputs.lint }}
+      uses: hadolint/hadolint-action@v3.0.0
+      with:
+        dockerfile: ${{ inputs.dockerFile }}
+        failure-threshold: "warning"
+        verbose: true
+
+    - name: Extract metadata (tags, labels) for Docker
+      id: meta
+      uses: docker/metadata-action@v4
+      env:
+        DOCKER_METADATA_PR_HEAD_SHA: "true"
+      with:
+        tags: |
+          type=ref,event=branch
+          type=ref,event=pr
+          type=sha
+          type=semver,pattern={{version}}
+          type=semver,pattern={{major}}.{{minor}}
+          type=semver,pattern={{major}}
+        images: ${{ inputs.images }}
+
+    - name: Build and push Docker image
+      uses: docker/build-push-action@v3
+      with:
+        context: ${{ inputs.context }}
+        file: ${{ inputs.dockerFile }}
+        build-args: ${{ inputs.dockerBuildArgs }}
+        push: true
+        tags: ${{ steps.meta.outputs.tags }}
+        labels: ${{ steps.meta.outputs.labels }}
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
+        target: ${{ inputs.target }}
+        provenance: ${{ inputs.provenance }}
+        secrets: ${{ secrets.dockerSecrets }}


### PR DESCRIPTION
## Changes
<!--
  What are you changing and what is the reason? If there are any UI changes, include a screenshot for the changes.
-->

Adds support for `additionalImages` argument, sent to `docker/metadata-action` action.

Breaks out the code part to an action as well, so users can use it as part of a larger workflow. this is to support being able to send it to other registries than standard ones