### PR TITLE
feat: Use provenance and OIDC authentication when publishing to npm

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -6,9 +6,6 @@ on:
       token:
         description: "The GitHub token"
         required: true
-      npmToken:
-        description: "NPM registry token"
-        required: true
     inputs:
       scope:
         type: string
@@ -88,5 +85,3 @@ jobs:
         # ############# PUBLISH TO NPM #############
 
       - run: yarn npm publish --access public --tag ${{ env.NPM_TAG }} --provenance
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.npmToken || secrets.NPM_TOKEN }}

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -38,6 +38,7 @@ jobs:
     permissions:
       contents: read
       packages: write
+      id-token: write
 
     steps:
       - name: Checkout repository
@@ -86,6 +87,6 @@ jobs:
 
         # ############# PUBLISH TO NPM #############
 
-      - run: yarn npm publish --access public --tag ${{ env.NPM_TAG }}
+      - run: yarn npm publish --access public --tag ${{ env.NPM_TAG }} --provenance
         env:
           YARN_NPM_AUTH_TOKEN: ${{ secrets.npmToken || secrets.NPM_TOKEN }}

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -89,4 +89,4 @@ jobs:
 
       - run: yarn npm publish --access public --tag ${{ env.NPM_TAG }} --provenance
         env:
-          YARN_NPM_AUTH_TOKEN: ${{ secrets.npmToken || secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.npmToken || secrets.NPM_TOKEN }}


### PR DESCRIPTION
<!--(
  Copy the id and paste it to the appropriate CLICKUP-<id> / FTRACK-<id> /  SENTRY-<id> / ZENDESK-<id> link.
  Please remember to remove the unused ones.
  
  * CLICKUP-
  * FT-
  * SENTRY-
  * ZENDESK-

-->

Resolves <!--Task reference -->

- [ ] I have added automatic tests where applicable.
- [ ] The PR contains a description of what has been changed.
- [ ] The description contains manual test instructions.
- [ ] The PR contains updates to the release notes.
- [ ] I have verified that the documentation is still up to date.

## Changes
<!--
  What are you changing and what is the reason? If there are any UI changes, include a screenshot for the changes.
-->

NPM has revoked classic npm token support which blocks our npm publishing flow, so we're moving to OIDC authentication with provenance.

Read more here:

https://github.blog/changelog/2025-12-09-npm-classic-tokens-revoked-session-based-auth-and-cli-token-management-now-available/

https://docs.npmjs.com/trusted-publishers

## Test
<!--
  How should this be tested? Include any requirements on other repositories or environment.
  For bug fixes, include the original reproduction steps.
-->
